### PR TITLE
Update skin-islands-input.styl

### DIFF
--- a/lib/skins/input/skin-islands-input.styl
+++ b/lib/skins/input/skin-islands-input.styl
@@ -34,7 +34,7 @@ skin-islands-input-view()
 
   box-shadow: $skin-islands-input-view-shadow
   
-  -webkit-appearance: textfield /* override for <input type="search"> */
+  -webkit-appearance: none /* override for <input type="search"> */
 
   unless no-focus in arguments
     &:not(.is-disabled):focus


### PR DESCRIPTION
Set `-webkit-appearance` to `none`. Fixes focus state in Safari.
