### PR TITLE
Change default text color to black

### DIFF
--- a/lib/variables/colors.styl
+++ b/lib/variables/colors.styl
@@ -2,7 +2,7 @@ $islands ?= {}
 
 // Remove wtf part when https://github.com/LearnBoost/stylus/issues/1177 would be fixed
 $temp_wtf_colors = {
-  text: #333,
+  text: #000,
   misc: rgba-ie(#000, 0.5),
   focus: rgba-ie(#FC0, 0.7),
   error: rgba-ie(#F00, 0.7),


### PR DESCRIPTION
Дизайнеры обнаружили, что цвет шрифта серый, что отличается от всех гайдов. Настоятельно просили сделать чёрным.
